### PR TITLE
Remove warning when aliases cannot be expanded

### DIFF
--- a/lib/polymorphic_embed.ex
+++ b/lib/polymorphic_embed.ex
@@ -3,7 +3,6 @@ defmodule PolymorphicEmbed do
 
   @type t() :: any()
 
-  require Logger
   require PolymorphicEmbed.OptionsValidator
 
   alias Ecto.Changeset
@@ -52,19 +51,7 @@ defmodule PolymorphicEmbed do
   # # ...
   #   polymorphic_embeds_one(:fallback_provider, types: @types)
   # which means we can't expand aliases
-  defp expand_alias(types, env) do
-    Logger.warning("""
-    Aliases could not be expanded for the given types in #{inspect(env.module)}.
-
-    This likely means the types are defined using a module attribute or another reference
-    that cannot be expanded at compile time. As a result, this may lead to unnecessary
-    compile-time dependencies, causing longer compilation times and unnecessary
-    re-compilation of modules (the parent defining the embedded types).
-
-    Ensure that the types are specified directly within the macro call to avoid these issues,
-    or refactor your code to eliminate references that cannot be expanded.
-    """)
-
+  defp expand_alias(types, _env) do
     types
   end
 


### PR DESCRIPTION
* The warning is trying to do the job of `mix xref` from a place of incomplete information. As the warning itself implies, it may be inaccurate.
* This is why ecto and phoenix and oban and other libs who expand like this don't try to warn in cases like "set a module attribute, use it." (In fact, the example in the comments [here](https://github.com/mathieuprog/polymorphic_embed/blob/8c874fe/lib/polymorphic_embed.ex#L51) doesn't actually cause a compile-time dep.)
* Instead they leave it to the compiler and `mix xref` to let the engineer know if there's a problem.
* In the case of false positives, the warning scares the engineer unnecessarily. We are experiencing this currently :)